### PR TITLE
Fix pagination bug, add existence check to parsed headers

### DIFF
--- a/imports/lib/github/github-interface.js
+++ b/imports/lib/github/github-interface.js
@@ -39,7 +39,7 @@ export default function (userId) {
           if (!res) return done()
           repos = _.union(repos, res.data.filter(isPlatformProject))
           let headers = parseGithubHeaders(res.headers.link)
-          if (headers.next) q.push(headers.next.url)
+          if (headers && headers.next) q.push(headers.next.url)
           done()
         })
       }), 1)


### PR DESCRIPTION
Parse link header can return null (https://github.com/thlorenz/parse-link-header/blob/master/index.js#L42) when there is no second page.

This PR guards against this.