### PR TITLE
Fixes allow deny issue

### DIFF
--- a/imports/api/pages/pages.js
+++ b/imports/api/pages/pages.js
@@ -1,6 +1,9 @@
 import { Mongo } from 'meteor/mongo'
+import everything from '/imports/lib/everything'
 
 let Pages = new Mongo.Collection('pages')
 Pages.rootName = 'Site Settings'
+
+Pages.deny(everything)
 
 export default Pages

--- a/imports/api/projects/projects.js
+++ b/imports/api/projects/projects.js
@@ -1,3 +1,8 @@
 import { Mongo } from 'meteor/mongo'
+import everything from '/imports/lib/everything'
 
-export default new Mongo.Collection('projects')
+const Projects = new Mongo.Collection('projects')
+
+Projects.deny(everything)
+
+export default Projects

--- a/imports/lib/everything.js
+++ b/imports/lib/everything.js
@@ -1,0 +1,9 @@
+const ohYes = () => true
+
+const everything = {
+  insert: ohYes,
+  update: ohYes,
+  remove: ohYes
+}
+
+export default everything


### PR DESCRIPTION
There's a security vuln in the combo of collection allow rules and packages like collections2
https://forums.meteor.com/t/meteor-allow-deny-vulnerability-disclosure/39500

We've set up our collections to 'allow' nothing, which should prevent client-side modification of the db, but it turns out that it'd be more secure to 'deny' everything, which sounds similar, but, with allowing nothing, it's possible for a package to add a 'allow: true' which would re-open the collection to direct modification. Only 1 deny rule need return true to block that, where only 1 allow rule need return true to defeat it

https://guide.meteor.com/security.html#allow-deny